### PR TITLE
Fix failing lint workflow

### DIFF
--- a/lib/blog/mailer.ex
+++ b/lib/blog/mailer.ex
@@ -1,3 +1,6 @@
 defmodule Blog.Mailer do
+  @moduledoc """
+  Documentation for Blog.Mailer
+  """
   use Swoosh.Mailer, otp_app: :blog
 end

--- a/lib/blog/posts/post.ex
+++ b/lib/blog/posts/post.ex
@@ -1,4 +1,7 @@
 defmodule Blog.Posts.Post do
+  @moduledoc """
+  Documentation for Blog.Posts.Post
+  """
   use Ecto.Schema
   import Ecto.Changeset
 

--- a/lib/blog_web/telemetry.ex
+++ b/lib/blog_web/telemetry.ex
@@ -1,4 +1,7 @@
 defmodule BlogWeb.Telemetry do
+  @moduledoc """
+  Documentation for BlogWeb.Telemetry
+  """
   use Supervisor
   import Telemetry.Metrics
 

--- a/test/support/data_case.ex
+++ b/test/support/data_case.ex
@@ -15,6 +15,7 @@ defmodule Blog.DataCase do
   """
 
   use ExUnit.CaseTemplate
+  alias Ecto.Adapters.SQL.Sandbox
 
   using do
     quote do
@@ -36,8 +37,8 @@ defmodule Blog.DataCase do
   Sets up the sandbox based on the test tags.
   """
   def setup_sandbox(tags) do
-    pid = Ecto.Adapters.SQL.Sandbox.start_owner!(Blog.Repo, shared: not tags[:async])
-    on_exit(fn -> Ecto.Adapters.SQL.Sandbox.stop_owner(pid) end)
+    pid = Sandbox.start_owner!(Blog.Repo, shared: not tags[:async])
+    on_exit(fn -> Sandbox.stop_owner(pid) end)
   end
 
   @doc """


### PR DESCRIPTION
As in #25, `Credo` uncovered our two sins, one of which is because we used the `--strict` option in the CI workflow file and the other.. well, that sneaky module doc! We could use `@moduledoc false` for any module we don't want to document but I wasn't sure so I just added dummy module docs for the three modules.